### PR TITLE
feat: add todo suggestion endpoint powered by llm

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ A Node.js microservice that exposes a REST API for managing todo items persisted
    PORT=3000
    NODE_ENV=development
    AUTH_SERVICE_URL=http://localhost:3001  # optional override
+   LLM_API_BASE_URL=https://api.openai.com/v1  # base URL for OpenAI-compatible API
+   LLM_API_KEY=                            # optional API key if the provider requires auth
+   LLM_SUGGESTION_MODEL=gpt-3.5-turbo      # model used for todo suggestions
    ```
 
    - `AUTH_SERVICE_URL` is read by the auth middleware and health check. If omitted, `http://localhost:3001` is used.
@@ -121,6 +124,7 @@ For multi-architecture builds, use `./build-docker.sh <tag>` to build amd64/arm6
 | GET | `/health` | Health status including DB and auth connectivity |
 | GET | `/to-do` | Retrieve all todos (requires auth) |
 | GET | `/to-do/:id` | Retrieve a single todo by ID (requires auth) |
+| GET | `/to-do/suggestions` | Generate suggested todos based on the three most recent items (requires auth) |
 | POST | `/to-do` | Create a new todo (requires auth) |
 | PUT | `/to-do/:id` | Update an existing todo (requires auth) |
 | DELETE | `/to-do/:id` | Delete a todo (requires auth) |

--- a/env.example
+++ b/env.example
@@ -8,3 +8,14 @@ DB_PASSWORD=password
 # Server Configuration
 PORT=3000
 NODE_ENV=development
+
+# Auth Service (optional override)
+AUTH_SERVICE_URL=http://localhost:3001
+
+# LLM Configuration for Todo Suggestions
+# Base URL for the OpenAI-compatible API (required)
+LLM_API_BASE_URL=https://api.openai.com/v1
+# API key for the OpenAI-compatible API (leave empty if not required)
+LLM_API_KEY=
+# Model used for generating suggestions
+LLM_SUGGESTION_MODEL=gpt-3.5-turbo

--- a/models/Todo.js
+++ b/models/Todo.js
@@ -26,6 +26,19 @@ class Todo {
     }
   }
 
+  // Get most recent todos with optional limit
+  static async getRecent(limit = 3) {
+    try {
+      const result = await pool.query(
+        'SELECT * FROM todos ORDER BY created_at DESC LIMIT $1',
+        [limit]
+      );
+      return result.rows;
+    } catch (error) {
+      throw new Error(`Error fetching recent todos: ${error.message}`);
+    }
+  }
+
   // Create new todo
   static async create(title, description = null, completed = false) {
     try {

--- a/services/llmService.js
+++ b/services/llmService.js
@@ -1,0 +1,135 @@
+const axios = require('axios');
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-3.5-turbo';
+
+const sanitizeBaseUrl = (url) => {
+  if (!url) return '';
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+};
+
+const buildPrompt = (recentTodos) => {
+  if (!recentTodos.length) {
+    return 'No todos have been created yet.';
+  }
+
+  const lines = recentTodos.map((todo, index) => {
+    const description = todo.description ? ` - Description: ${todo.description}` : '';
+    return `${index + 1}. Title: ${todo.title}${description}`;
+  });
+
+  return `Here are the most recent todos:
+${lines.join('\n')}`;
+};
+
+const parseSuggestions = (content) => {
+  if (!content || typeof content !== 'string') {
+    throw new Error('LLM response did not include suggestions.');
+  }
+
+  const trimmedContent = content.trim();
+
+  const tryParse = (text) => {
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      return null;
+    }
+  };
+
+  let suggestions = tryParse(trimmedContent);
+
+  if (!suggestions) {
+    const jsonMatch = trimmedContent.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      suggestions = tryParse(jsonMatch[0]);
+    }
+  }
+
+  if (!Array.isArray(suggestions)) {
+    throw new Error('LLM response was not in the expected JSON array format.');
+  }
+
+  return suggestions
+    .map((suggestion) => ({
+      title: suggestion.title || suggestion.Title || suggestion.name || suggestion.Name,
+      description:
+        suggestion.description ||
+        suggestion.Description ||
+        suggestion.details ||
+        suggestion.Details ||
+        '',
+    }))
+    .filter((suggestion) => suggestion.title)
+    .map((suggestion) => ({
+      title: String(suggestion.title).trim(),
+      description: suggestion.description ? String(suggestion.description).trim() : '',
+    }));
+};
+
+const generateTodoSuggestions = async (recentTodos) => {
+  const baseUrl = sanitizeBaseUrl(process.env.LLM_API_BASE_URL || DEFAULT_BASE_URL);
+  const apiKey = process.env.LLM_API_KEY;
+  const model = process.env.LLM_SUGGESTION_MODEL || DEFAULT_MODEL;
+
+  if (!baseUrl) {
+    throw new Error('LLM_API_BASE_URL is not configured.');
+  }
+
+  if (!model) {
+    throw new Error('LLM_SUGGESTION_MODEL is not configured.');
+  }
+
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const payload = {
+    model,
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are a helpful assistant that generates actionable, concise todo suggestions. Always respond with a JSON array of objects with "title" and "description" fields.',
+      },
+      {
+        role: 'user',
+        content: `${buildPrompt(recentTodos)}\n\nBased on these todos, suggest three new, unique todos that would complement the list. Respond using only JSON.`,
+      },
+    ],
+    temperature: 0.7,
+    n: 1,
+  };
+
+  try {
+    const response = await axios.post(`${baseUrl}/chat/completions`, payload, {
+      headers,
+      timeout: 10000,
+    });
+
+    const content = response?.data?.choices?.[0]?.message?.content;
+    const suggestions = parseSuggestions(content);
+
+    if (!suggestions.length) {
+      throw new Error('No suggestions returned by LLM.');
+    }
+
+    return suggestions;
+  } catch (error) {
+    if (error.response) {
+      const { status, data } = error.response;
+      throw new Error(`LLM request failed with status ${status}: ${data?.error?.message || data?.message || 'Unknown error'}`);
+    }
+
+    throw new Error(`Failed to generate suggestions: ${error.message}`);
+  }
+};
+
+module.exports = {
+  generateTodoSuggestions,
+};
+


### PR DESCRIPTION
## Summary
- add an authenticated `/to-do/suggestions` route that calls a helper to generate suggestions from the three most recent todos
- implement an OpenAI-compatible LLM client to request structured todo suggestions with optional API key support
- document the new environment variables and configuration in the README and example env file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8e961e94832ab6807f2db1cca6eb